### PR TITLE
when bind_to_interface not equal null and not equal 'null', set strea…

### DIFF
--- a/src/IO/StreamSocket.php
+++ b/src/IO/StreamSocket.php
@@ -92,10 +92,11 @@ class StreamSocket extends AbstractIO
     public static function withConfiguration($host, $port, Configuration $configuration, EventDispatcher $eventDispatcher = null)
     {
         $context = null;
-        if (null !== $configuration->getValue('bind_to_interface')) {
+        $bindToInterface =  $configuration->getValue('bind_to_interface');
+        if (null !== $bindToInterface && 'null' !== $bindToInterface) {
             $context = stream_context_create([
                 'socket' => [
-                    'bindto' => $configuration->getValue('bind_to_interface')
+                    'bindto' => $bindToInterface
                 ]
             ]);
         }


### PR DESCRIPTION
when use in swoole 4.4.18+ or 4.5+ or higher php，will happen warning notice. PS: warning message will like this (Failed to parse address "null"）